### PR TITLE
Fix/tao 7149 extension manager jqueryui dialog

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'Development Tools',
     'description' => 'Developer tools that can assist you in creating new extensions, run scripts, destroy your install',
     'license' => 'GPL-2.0',
-    'version' => '4.2.2',
+    'version' => '4.2.3',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'generis' => '>=6.14.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -33,6 +33,6 @@ class Updater extends \common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-        $this->skip('0', '4.2.2');
+        $this->skip('0', '4.2.3');
     }
 }

--- a/views/templates/extensionManager/view.tpl
+++ b/views/templates/extensionManager/view.tpl
@@ -64,9 +64,18 @@
 			</tbody>
 		</table>
 	</form>
-
-<div id="installProgress" title="<?= __('Installation...') ?>">
-	<div class="progress"><div class="bar"></div></div>
-	<p class="status">...</p>
-	<div class="console"></div>
+<div id="installProgress" class="modal" title="<?= __('Installation...') ?>">
+    <div class="modal-body">
+        <div class="progress"><div class="bar"></div></div>
+        <p class="status">...</p>
+        <div class="console"></div>
+        <div class="buttons rgt">
+            <button class="btn-info small key-navigation-highlight" data-control="cancel" type="button">
+                <span class="label"><?= __('No') ?></span>
+            </button>
+            <button class="btn-info small key-navigation-highlight" data-control="confirm" type="button">
+                <span class="label"><?= __('Yes') ?></span>
+            </button>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Regression found in https://oat-sa.atlassian.net/browse/TAO-7149
Follow up https://github.com/oat-sa/tao-core/pull/2085
 
 - The dependency to `jqueryui` wasn't declared by the module itself. It was working by chance (another module had to import it previously)
 - This PR brings a quick fix to use `ui/modal` instead of jqueryui's `dialog` 
 - This controller is a non sense by itself since it duplicates another controller at 90%, but the goal of this PR is fix a regression only. 

How to reproduce : 
 - Ensure your instance is in `DEBUG_MODE` (in `config/generis.conf.php`)
 - Open the `Extension Manager` from `Settings`
 - Install the extension _taoDevTools_
 - Select extensions and click the `Install` button

What's expected : 
 - A modal popup is displayed, you can confirm or cancel the installation, follow up the installation progress  