### PR TITLE
REL-1324: Load test TAO.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,12 +49,14 @@
 		"symfony/process": "^5.0",
 		"ccampbell/chromephp": "~4.1.0",
 		"nette/php-generator": "~3.3.0",
-		"dephpend/dephpend": "^0.6.3",
 		"oat-sa/generis" : ">=15.17.0",
 		"oat-sa/tao-core" : ">=48.11.0",
 		"oat-sa/extension-tao-group" : ">=7.0.0",
 		"oat-sa/extension-tao-item" : ">=11.0.0",
 		"oat-sa/extension-tao-itemqti" : ">=28.2.0"
+	},
+	"require-dev": {
+		"dephpend/dephpend": "^0.6.3"
 	},
 	"autoload": {
 		"psr-4": {

--- a/scripts/tools/DepsInfo.php
+++ b/scripts/tools/DepsInfo.php
@@ -267,6 +267,11 @@ color: darkred;
             . 'dephpend' . DIRECTORY_SEPARATOR
             . 'dephpend' . DIRECTORY_SEPARATOR
             . 'bin' . DIRECTORY_SEPARATOR . 'dephpend';
+        if (!file_exists($pathToDephpend)) {
+            throw new \RuntimeException(
+                'dePHPend extension is not installed, please install it before running command.'
+            );
+        }
         $command = 'php ' . $pathToDephpend . ' text ' . $fileInfo;
         $dependencies = shell_exec($command);
         $dependenciesArray = preg_split("/\r\n|\n|\r/", $dependencies);


### PR DESCRIPTION
## Goal
It is crucial to ensure that the new setup can handle the expected load and perform optimally under different conditions. This task involves conducting load testing on TAO to validate its reliability, scalability, and performance.

## Changelog
- fix: unfortunately dePHPend is not yet compatible with PHP8+, so we need to make it optional in order to install extension.

## How to test / use
`composer require oat-sa/extension-tao-devtools` should install extension without any issues.


## Dependencies
- https://github.com/oat-sa/extension-tao-devtools/pull/100