### PR TITLE
chore: use latest dephpend/dephpend to be compatible with required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "oat-sa/extension-tao-itemqti": ">=28.2.0"
   },
   "require-dev": {
-    "dephpend/dephpend": "^0.8.0"
+    "dephpend/dephpend": "^0.9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
use latest dephpend/dephpend to be compatible with required php version